### PR TITLE
Remove redundant Git card from cards.csv

### DIFF
--- a/cards.csv
+++ b/cards.csv
@@ -70,5 +70,4 @@
 "OpenJDK",5,"Mainstream Adoption","Implémentation libre et open source de la plateforme Java Standard Edition.","Java","Technological"
 "GNU",3,"Free Software Movement","Projet initié par Richard Stallman visant à créer un système d'exploitation entièrement libre.","Unix","Organizational"
 "Distributed Revision Control System",5,"Mainstream Adoption","Systèmes permettant de gérer les versions de projets de manière distribuée, facilitant la collaboration.","Git","Technological"
-"Git",5,"Mainstream Adoption","Système de contrôle de version distribué, conçu pour gérer tout, des petits aux très grands projets avec rapidité et efficacité.","Linux Kernel","Technological"
 "Chromebooks",6,"Modern Open Source","Ordinateurs portables exécutant Chrome OS, un système basé sur Linux centré sur le navigateur web.","Linux Kernel","Technological"


### PR DESCRIPTION
## Description

"Git" and "Git & GitHub" overlap conceptually in the current deck, while "Microsoft Acquires GitHub" depends on "Git & GitHub".

To reduce redundancy and maintain consistency with the dependency rules, I removed the standalone "Git" card and kept "Git & GitHub" as a broader collaborative development milestone.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [ ] Documentation update 
- [x] Refactoring 
- [ ] Other (please describe):

## How was this tested?

I verified that the CSV structure remains valid after removing the "Git" row and that no syntax issues were introduced. The remaining cards and dependencies are consistent with the game rules.

## Related issues

None

## Checklist

- [x] I have tested my changes locally
- [x] I have added comments/documentation where needed
- [ ] I have linked related issues
- [x] I am ready for review